### PR TITLE
Initialize logger

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,4 @@
+{
+  "root": true,
+  "extends": ["eslint-config-mm"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+coverage

--- a/.istanbul.yml
+++ b/.istanbul.yml
@@ -1,0 +1,6 @@
+check:
+  global:
+    statements: 100
+    lines: 100
+    branches: 100
+    functions: 100

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+ sudo: false
+
+ language: node_js
+ node_js: "4.2"
+ 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@
  language: node_js
  node_js: "4.2"
  
+ after_script: "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 Enrise node-logger
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,67 @@
 # Node.js logger module
+> A simple wrapper around [winston](https://github.com/winstonjs/winston).
+
+### Installation
+NPM: `npm install enrise-node-logger --save`  
+Yarn: `yarn add enrise-node-logger`
+
+### Initialization and usage
+At the beginning of your application, be sure to initialize the logger:  
+`require('enrise-node-logger')([config: Object]);`
+
+Where `config` is an optional object. See [below](#configuration) for further instructions.
+
+After the module is initialized, simply call `.get(name: String)` on the module to return a namespaced logger:
+`const log = require('enrise-node-logger').get('MyLogger');`
+
+The `log` object contains functions for each [log-level](#levels):
+- `log.info('Some log message');`  
+- `log.error(new Error('Some error'));`
+
+### Configuration
+
+The default configuration looks as follows. Everything can be overwritten on initialization.
+```javascript
+{
+  transports: ['Console'],
+  getConsoleConfig: (config) => {
+    return config.console;
+  },
+  getLogstashUDPConfig: (config) => {
+    return config.logstash;
+  },
+  winston: {
+    console: {
+      level: 'info',
+      colorize: true
+    },
+    logstash: {}
+  },
+  levels: {
+    error: 0,
+    warn: 1,
+    help: 2,
+    data: 3,
+    info: 4,
+    trace: 5,
+    debug: 6,
+    prompt: 7,
+    verbose: 8
+  }
+}
+```
+
+#### `transports`
+Define all transports that the logger should use. Defaults to only the Console. The other possible transport is `LogstashUDP`. These can be used together.
+
+#### `getConsoleConfig` & `getLogstashUDPConfig`
+Overwrite and modify the configuration used for their corresponding transport. The `config` object is _always_ a clone of the `config.winston` object.
+
+#### `winston`
+An object with specific configuration for the transporters.
+- `console`: [winston.Console documentation](https://github.com/winstonjs/winston)
+- `logstash`: [winston.LogstashUDP documentation](https://www.npmjs.com/package/winston-logstash-udp)
+
+#### `levels`
+The node-logger uses more detailed log-levels than winston does. The higher the priority the more important the message is considered to be, and the lower the corresponding integer priority. These levels can be modified to your liking.
+

--- a/index.js
+++ b/index.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const defaultSettings = require('./settings.js');
+
+const _ = require('lodash');
+const winston = require('winston');
+require('winston-logstash-udp');
+
+function Logger(settings) {
+  if (!(this instanceof Logger)) {
+    return new Logger(settings);
+  }
+
+  this._settings = _.defaultsDeep(settings, defaultSettings);
+  this._container = new winston.Container({
+    exitOnError: false
+  });
+
+  // Overwrite module, this instance will be included on next require.
+  module.exports = this;
+}
+
+Logger.prototype.get = function (label, level) {
+  const conf = _.cloneDeep(this._settings.winston);
+
+  conf.console.label = label;
+  conf.console.level = level || conf.console.level;
+
+  const transports = _.map(this._settings.transports, (transport) => {
+    const transportConfig = this._settings[`get${transport}Config`](conf);
+
+    return new winston.transports[transport](transportConfig);
+  });
+
+  // Create a new logger with the console transport layer by default
+  return this._container.get(label, {
+    transports: transports
+  }).setLevels(this._settings.levels);
+};
+
+// Protect against usage without instantiation
+Logger.get = () => {
+  throw new Error('Logger not instantiated');
+};
+
+module.exports = Logger;

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
+    "coveralls": "^2.11.14",
     "eslint": "^3.8.1",
     "eslint-config-mm": "^1.1.1",
     "istanbul": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.0",
   "author": "Team MatchMinds @ Enrise",
   "main": "index.js",
+  "license": "MIT",
   "engines": {
     "node": ">=4.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "enrise-logger",
+  "description": "Logger used within Enrise projects and module's",
+  "version": "0.0.0",
+  "author": "Team MatchMinds @ Enrise",
+  "main": "index.js",
+  "engines": {
+    "node": ">=4.0.0"
+  },
+  "scripts": {
+    "lint": "eslint index.js test",
+    "unittest": "mocha test/*.spec.js",
+    "cover": "istanbul cover _mocha -- -R spec test/*.spec.js; istanbul check-coverage",
+    "test": "npm run lint && npm run cover"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Enrise/node-logger"
+  },
+  "bugs": {
+    "url": "https://github.com/Enrise/node-logger/issues"
+  },
+  "dependencies": {
+    "lodash": "^4.16.4",
+    "longjohn": "^0.2.11",
+    "winston": "^2.2.0",
+    "winston-logstash-udp": "^0.1.1"
+  },
+  "devDependencies": {
+    "chai": "^3.5.0",
+    "eslint": "^3.8.1",
+    "eslint-config-mm": "^1.1.1",
+    "istanbul": "^0.4.5",
+    "mocha": "^3.1.2",
+    "proxyquire": "^1.7.10",
+    "sinon": "^1.17.6",
+    "sinon-chai": "^2.8.0"
+  }
+}

--- a/settings.js
+++ b/settings.js
@@ -1,0 +1,28 @@
+module.exports = {
+  getConsoleConfig: (config) => {
+    return config.console;
+  },
+  getLogstashUDPConfig: (config) => {
+    return config.logstash;
+  },
+  transports: ['Console'],
+  longtrace: false,
+  winston: {
+    console: {
+      level: 'info',
+      colorize: true
+    },
+    logstash: {}
+  },
+  levels: {
+    error: 0,
+    warn: 1,
+    help: 2,
+    data: 3,
+    info: 4,
+    trace: 5,
+    debug: 6,
+    prompt: 7,
+    verbose: 8
+  }
+};

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,8 @@
+{
+  "env": {
+    "mocha": true
+  },
+  "rules": {
+    "no-unused-expressions": 0
+  }
+}

--- a/test/logger.spec.js
+++ b/test/logger.spec.js
@@ -1,0 +1,159 @@
+'use strict';
+
+const _ = require('lodash');
+const chai = require('chai');
+const sinon = require('sinon');
+const proxyquire = require('proxyquire').noCallThru();
+const expect = chai.expect;
+chai.use(require('sinon-chai'));
+
+const levels = {
+  error: 0,
+  warn: 1,
+  help: 2,
+  data: 3,
+  info: 4,
+  trace: 5,
+  debug: 6,
+  prompt: 7,
+  verbose: 8
+};
+
+const winstonCLI = {
+  log: sinon.stub()
+};
+
+const winstonLogger = {
+  setLevels: sinon.stub()
+};
+
+const winstonContainer = {
+  get: sinon.stub().returns(winstonLogger)
+};
+
+const winston = {
+  loggers: {
+    add: sinon.stub().returns(winstonCLI)
+  },
+  transports: {
+    Console: sinon.stub(),
+    LogstashUDP: sinon.stub()
+  },
+  Container: sinon.stub().returns(winstonContainer)
+};
+
+// Keep reference to main Logger constructor.
+const Logger = proxyquire('../index.js', {
+  winston: winston
+});
+
+describe('Logger', () => {
+  it('throws an error when trying to use without instantiating', () => {
+    let err;
+    try {
+      Logger.get('TestLogger');
+    } catch (e) {
+      err = e;
+    }
+    expect(err).to.not.equal(undefined);
+    expect(err.message).to.equal('Logger not instantiated');
+  });
+
+  it('correctly instantiates without `new` and overwrites the module after instantiation', () => {
+    const logger = require('../index.js')();
+    expect(logger).to.equal(require('../index.js'));
+  });
+
+  it('instantiates with `new` and overwrites the module', () => {
+    const logger = new Logger();
+    expect(logger).to.equal(require('../index.js'));
+  });
+
+  it('overwrites and merges with default settings', () => {
+    const logger = new Logger({
+      winston: {
+        console: {
+          level: 'verbose'
+        }
+      }
+    });
+    expect(logger._settings).to.deep.equal({
+      transports: ['Console'],
+      getConsoleConfig: logger._settings.getConsoleConfig,
+      getLogstashUDPConfig: logger._settings.getLogstashUDPConfig,
+      longtrace: false,
+      winston: {
+        console: {
+          level: 'verbose',
+          colorize: true
+        },
+        logstash: {}
+      },
+      levels: levels
+    });
+    expect(logger._settings.getConsoleConfig).to.be.a('function');
+    expect(logger._settings.getLogstashUDPConfig).to.be.a('function');
+  });
+
+  it('creates the default transports defined by config.transports', () => {
+    new Logger().get('TEST');
+    expect(winston.transports.Console).to.have.been.calledWith({
+      level: 'info',
+      colorize: true,
+      label: 'TEST'
+    });
+  });
+
+  it('calls a custom get config function with a clone of the winston data', () => {
+    let winstonConfig;
+    const loggerConfig = {
+      winston: {
+        console: {}
+      },
+      getConsoleConfig: (_config) => {
+        winstonConfig = _config;
+        return winstonConfig;
+      }
+    };
+    new Logger(loggerConfig).get('LABEL');
+    expect(loggerConfig.winston).to.not.equal(winstonConfig);
+    expect(_.set(loggerConfig.winston, 'console.label', 'LABEL')).to.deep.equal(winstonConfig);
+  });
+
+  it('calls a custom get config function for the console transport', () => {
+    new Logger({
+      getConsoleConfig: () => {
+        return {
+          foo: 'bar'
+        };
+      }
+    }).get('TEST');
+    expect(winston.transports.Console).to.have.been.calledWith({
+      foo: 'bar'
+    });
+  });
+
+  it('correctly sets the log-levels', () => {
+    new Logger().get('TEST');
+    expect(winstonLogger.setLevels).to.have.been.calledWith(levels);
+  });
+
+  it('allows modifying the transports configuration', () => {
+    new Logger({
+      transports: ['Console', 'LogstashUDP'],
+      winston: {
+        logstash: {
+          bar: 'foo'
+        }
+      }
+    }).get('TEST');
+    expect(winston.transports.Console).to.have.been.calledWith({
+      level: 'info',
+      colorize: true,
+      label: 'TEST'
+    });
+    expect(winston.transports.LogstashUDP).to.have.been.calledWith({
+      bar: 'foo'
+    });
+  });
+});


### PR DESCRIPTION
### Context
Create a utility package for our logger code.

### What has been done
- Initialize logger code
- Write tests
- Add coverage
- Set up npm scripts for running tests, including coverage
- Write README

### How to test
- Run `npm test`
- Test coverage at 100%

### Notes
node-logger is [taken](https://www.npmjs.com/package/node-logger) on npm. Therefore the package name is enrise-logger. What do you think we should do here?