### PR TITLE
Normalize setting label + level on transport options

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ The default configuration looks as follows. Everything can be overwritten on ini
     return config.console;
   },
   getLogstashUDPConfig: (config) => {
-    return config.logstash;
+    return config.logstashUDP;
   },
   winston: {
     console: {
       level: 'info',
       colorize: true
     },
-    logstash: {}
+    logstashUDP: {}
   },
   levels: {
     error: 0,
@@ -66,7 +66,7 @@ Overwrite and modify the configuration used for their corresponding transport. T
 #### `winston`
 An object with specific configuration for the transporters.
 - `console`: [winston.Console documentation](https://github.com/winstonjs/winston)
-- `logstash`: [winston.LogstashUDP documentation](https://www.npmjs.com/package/winston-logstash-udp)
+- `logstashUDP`: [winston.LogstashUDP documentation](https://www.npmjs.com/package/winston-logstash-udp)
 
 #### `levels`
 The node-logger uses more detailed log-levels than winston does. The higher the priority the more important the message is considered to be, and the lower the corresponding integer priority. These levels can be modified to your liking.

--- a/index.js
+++ b/index.js
@@ -23,10 +23,12 @@ function Logger(settings) {
 Logger.prototype.get = function (label, level) {
   const conf = _.cloneDeep(this._settings.winston);
 
-  conf.console.label = label;
-  conf.console.level = level || conf.console.level;
-
   const transports = _.map(this._settings.transports, (transport) => {
+    const transportSettings = conf[_.lowerFirst(transport)];
+
+    transportSettings.label = label;
+    transportSettings.level = level || transportSettings.level;
+
     const transportConfig = this._settings[`get${transport}Config`](conf);
 
     return new winston.transports[transport](transportConfig);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "enrise-logger",
   "description": "Logger used within Enrise projects and module's",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "Team MatchMinds @ Enrise",
   "main": "index.js",
   "license": "MIT",

--- a/settings.js
+++ b/settings.js
@@ -3,7 +3,7 @@ module.exports = {
     return config.console;
   },
   getLogstashUDPConfig: (config) => {
-    return config.logstash;
+    return config.logstashUDP;
   },
   transports: ['Console'],
   longtrace: false,
@@ -12,7 +12,7 @@ module.exports = {
       level: 'info',
       colorize: true
     },
-    logstash: {}
+    logstashUDP: {}
   },
   levels: {
     error: 0,

--- a/test/logger.spec.js
+++ b/test/logger.spec.js
@@ -87,7 +87,7 @@ describe('Logger', () => {
           level: 'verbose',
           colorize: true
         },
-        logstash: {}
+        logstashUDP: {}
       },
       levels: levels
     });
@@ -142,8 +142,9 @@ describe('Logger', () => {
     new Logger({
       transports: ['Console', 'LogstashUDP'],
       winston: {
-        logstash: {
-          bar: 'foo'
+        logstashUDP: {
+          bar: 'foo',
+          level: 'verbose'
         }
       }
     }).get('TEST');
@@ -153,7 +154,9 @@ describe('Logger', () => {
       label: 'TEST'
     });
     expect(winston.transports.LogstashUDP).to.have.been.calledWith({
-      bar: 'foo'
+      bar: 'foo',
+      level: 'verbose',
+      label: 'TEST'
     });
   });
 });


### PR DESCRIPTION
### Context
By default the logger set label+level on the console configuration. However, each transport is optional and other transports require label+level too.

### What has been done
- Set label+level on the individual transport configuration.

### How to test
- `npm test`