### PR TITLE
Simplify configuration and remove getXConfig functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,19 +29,11 @@ The `log` object contains functions for each [log-level](#levels):
 The default configuration looks as follows. Everything can be overwritten on initialization.
 ```javascript
 {
-  transports: ['Console'],
-  getConsoleConfig: (config) => {
-    return config.console;
-  },
-  getLogstashUDPConfig: (config) => {
-    return config.logstashUDP;
-  },
-  winston: {
-    console: {
+  transports: {
+    Console: {
       level: 'info',
       colorize: true
-    },
-    logstashUDP: {}
+    }
   },
   levels: {
     error: 0,
@@ -57,17 +49,12 @@ The default configuration looks as follows. Everything can be overwritten on ini
 }
 ```
 
-#### `transports`
-Define all transports that the logger should use. Defaults to only the Console. The other possible transport is `LogstashUDP`. These can be used together.
-
-#### `getConsoleConfig` & `getLogstashUDPConfig`
-Overwrite and modify the configuration used for their corresponding transport. The `config` object is _always_ a clone of the `config.winston` object.
-
-#### `winston`
-An object with specific configuration for the transporters.
-- `console`: [winston.Console documentation](https://github.com/winstonjs/winston)
-- `logstashUDP`: [winston.LogstashUDP documentation](https://www.npmjs.com/package/winston-logstash-udp)
+#### `transports: Object`
+The keys define the transports that the logger should use, the value is the configuration passed to the transport constructor. Multiple transports can be combined. Defaults to only the Console with the settings above. To exclude the Console transport, set it to `null`. Possible transports are:
+- `Console`: [winston.Console documentation](https://github.com/winstonjs/winston/blob/master/docs/transports.md#console-transport)
+- `File`: [winston.File documentation](https://github.com/winstonjs/winston/blob/master/docs/transports.md#file-transport)
+- `Http`: [winston.Http documentation](https://github.com/winstonjs/winston/blob/master/docs/transports.md#http-transport)
+- `LogstashUDP`: [winston.LogstashUDP documentation](https://www.npmjs.com/package/winston-logstash-udp)
 
 #### `levels`
 The node-logger uses more detailed log-levels than winston does. The higher the priority the more important the message is considered to be, and the lower the corresponding integer priority. These levels can be modified to your liking.
-

--- a/index.js
+++ b/index.js
@@ -21,17 +21,18 @@ function Logger(settings) {
 }
 
 Logger.prototype.get = function (label, level) {
-  const conf = _.cloneDeep(this._settings.winston);
+  const conf = _.cloneDeep(this._settings.transports);
 
-  const transports = _.map(this._settings.transports, (transport) => {
-    const transportSettings = conf[_.lowerFirst(transport)];
+  // Filter out falsey values
+  const transportKeys = _.keys(_.pickBy(this._settings.transports, _.identity));
+
+  const transports = _.map(transportKeys, (transport) => {
+    const transportSettings = conf[transport];
 
     transportSettings.label = label;
     transportSettings.level = level || transportSettings.level;
 
-    const transportConfig = this._settings[`get${transport}Config`](conf);
-
-    return new winston.transports[transport](transportConfig);
+    return new winston.transports[transport](transportSettings);
   });
 
   // Create a new logger with the console transport layer by default

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "enrise-logger",
   "description": "Logger used within Enrise projects and module's",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "author": "Team MatchMinds @ Enrise",
   "main": "index.js",
   "license": "MIT",

--- a/settings.js
+++ b/settings.js
@@ -1,19 +1,11 @@
 module.exports = {
-  getConsoleConfig: (config) => {
-    return config.console;
-  },
-  getLogstashUDPConfig: (config) => {
-    return config.logstashUDP;
-  },
-  transports: ['Console'],
-  longtrace: false,
-  winston: {
-    console: {
+  transports: {
+    Console: {
       level: 'info',
       colorize: true
-    },
-    logstashUDP: {}
+    }
   },
+  longtrace: false,
   levels: {
     error: 0,
     warn: 1,


### PR DESCRIPTION
### Context
Defining an array of which transports to use as well as an object for configuration for them is overengineering. Also, `getXConfig` functions weren't used so let's remove them.

### What has been done
- Simplify configuration.
- Remove `getXConfig` functions.
- Update package version, tests and README