### PR TITLE
Higher customization options of transports

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ The `log` object contains functions for each [log-level](#levels):
 - `log.info('Some log message');`  
 - `log.error(new Error('Some error'));`
 
+#### `.get(name: String, [level: String], [transportConfig: Object])`
+The `.get()` function allows additional customization. The level can overwrite the logging-level defined during initialization. A third argument can be passed to overwrite transport configuration. This will be merged onto the object passed to the transports.
+
 ### Configuration
 
 The default configuration looks as follows. Everything can be overwritten on initialization.

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function Logger(settings) {
 Logger.prototype.get = function (label, level, transportConfig) {
   const conf = _.cloneDeep(this._settings.transports);
 
-  if (transportConfig) {
+  if (_.isPlainObject(transportConfig)) {
     _.merge(conf, transportConfig);
   }
 

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function Logger(settings) {
     return new Logger(settings);
   }
 
-  this._settings = _.defaultsDeep(settings, defaultSettings);
+  this._settings = _.defaultsDeep(_.cloneDeep(settings), defaultSettings);
   this._container = new winston.Container({
     exitOnError: false
   });
@@ -20,8 +20,12 @@ function Logger(settings) {
   module.exports = this;
 }
 
-Logger.prototype.get = function (label, level) {
+Logger.prototype.get = function (label, level, transportConfig) {
   const conf = _.cloneDeep(this._settings.transports);
+
+  if (transportConfig) {
+    _.merge(conf, transportConfig);
+  }
 
   // Filter out falsey values
   const transportKeys = _.keys(_.pickBy(this._settings.transports, _.identity));

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "enrise-logger",
   "description": "Logger used within Enrise projects and module's",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "Team MatchMinds @ Enrise",
   "main": "index.js",
   "license": "MIT",

--- a/test/logger.spec.js
+++ b/test/logger.spec.js
@@ -143,4 +143,39 @@ describe('Logger', () => {
       label: 'TEST'
     });
   });
+
+  it('clones the passed configuration', () => {
+    const config = {
+      foo: 'bar',
+      deep: {
+        yes: []
+      }
+    };
+
+    const logger = new Logger(config);
+
+    // Default values will be merged on the config, it is not modified if it is still the same.
+    expect(config).to.deep.equal({
+      foo: 'bar',
+      deep: {
+        yes: []
+      }
+    });
+    expect(config).to.not.equal(logger._settings);
+  });
+
+  it('allows passing extra transport configuration to the .get() function', () => {
+    new Logger().get('label', null, {
+      Console: {
+        extra: 'settings'
+      }
+    });
+
+    expect(winston.transports.Console).to.have.been.calledWith({
+      level: 'info',
+      colorize: true,
+      extra: 'settings',
+      label: 'label'
+    });
+  });
 });


### PR DESCRIPTION
### Context
We require a bit more flexibility around configuring transports. The `.get()` function on the logger instance should be able to handle modifying the transport-config.

### What has been done
- Allow passing extra transport configuration to the .get() function.
- Update version number
- Update README
