### PR TITLE
Allow overrriding of Loglevel through config

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,20 +8,20 @@
 > A simple wrapper around [winston](https://github.com/winstonjs/winston).
 
 ### Installation
-NPM: `npm install enrise-logger --save`  
+NPM: `npm install enrise-logger --save`
 Yarn: `yarn add enrise-logger`
 
 ### Initialization and usage
-At the beginning of your application, be sure to initialize the logger:  
+At the beginning of your application, be sure to initialize the logger:
 `require('enrise-logger')([config: Object]);`
 
 Where `config` is an optional object. See [below](#configuration) for further instructions.
 
-After the module is initialized, simply call `.get(name: String)` on the module to return a namespaced logger:  
+After the module is initialized, simply call `.get(name: String)` on the module to return a namespaced logger:
 `const log = require('enrise-logger').get('MyLogger');`
 
 The `log` object contains functions for each [log-level](#levels):
-- `log.info('Some log message');`  
+- `log.info('Some log message');`
 - `log.error(new Error('Some error'));`
 
 #### `.get(name: String, [level: String], [transportConfig: Object])`
@@ -32,32 +32,60 @@ The `.get()` function allows additional customization. The level can overwrite t
 The default configuration looks as follows. Everything can be overwritten on initialization.
 ```javascript
 {
-  transports: {
-    Console: {
-      level: 'info',
-      colorize: true
+  winston: {
+    transports: {
+      Console: {
+        level: 'info',
+        colorize: true
+      }
+    },
+    levels: {
+      error: 0,
+      warn: 1,
+      help: 2,
+      data: 3,
+      info: 4,
+      trace: 5,
+      debug: 6,
+      prompt: 7,
+      verbose: 8
     }
-  },
-  levels: {
-    error: 0,
-    warn: 1,
-    help: 2,
-    data: 3,
-    info: 4,
-    trace: 5,
-    debug: 6,
-    prompt: 7,
-    verbose: 8
   }
 }
 ```
 
-#### `transports: Object`
+#### `winston: Object`
+The top-level key `winston` in the config contains winston-specific configuration.
+
+#### `<namedloggerKey>: {level: String}`
+You can add other toplevel-keys
+to provide named-logger specific level-information. This functionality allows you to set the log-level through configuration
+
+``` javascript
+{
+  winston: {...},
+  namedlogger1: {
+    level: debug
+  }
+}
+```
+
+The above configuration would set the `level` of logging to `debug` for the logger which was created as follows:
+
+```javascript
+const log = require('enrise-logger').get('NamedLogger1');
+```
+
+Be aware that the way you'll read and apply your config dictates the actions you should take to change the actual log-level
+at run-time. If you only read and apply the config at the start of your program you'd have to restart your program to apply the changed log-level.
+
+#### `winston.transports: Object`
 The keys define the transports that the logger should use, the value is the configuration passed to the transport constructor. Multiple transports can be combined. Defaults to only the Console with the settings above. To exclude the Console transport, set it to `null`. Possible transports are:
+
 - `Console`: [winston.Console documentation](https://github.com/winstonjs/winston/blob/master/docs/transports.md#console-transport)
 - `File`: [winston.File documentation](https://github.com/winstonjs/winston/blob/master/docs/transports.md#file-transport)
 - `Http`: [winston.Http documentation](https://github.com/winstonjs/winston/blob/master/docs/transports.md#http-transport)
 - `LogstashUDP`: [winston.LogstashUDP documentation](https://www.npmjs.com/package/winston-logstash-udp)
 
-#### `levels`
+#### `winston.levels`
 The node-logger uses more detailed log-levels than winston does. The higher the priority the more important the message is considered to be, and the lower the corresponding integer priority. These levels can be modified to your liking.

--- a/README.md
+++ b/README.md
@@ -8,19 +8,20 @@
 > A simple wrapper around [winston](https://github.com/winstonjs/winston).
 
 ### Installation
-NPM: `npm install enrise-logger --save`
+NPM: `npm install enrise-logger --save`  
 Yarn: `yarn add enrise-logger`
 
 ### Initialization and usage
-At the beginning of your application, be sure to initialize the logger:
+At the beginning of your application, be sure to initialize the logger:  
 `require('enrise-logger')([config: Object]);`
 
 Where `config` is an optional object. See [below](#configuration) for further instructions.
 
-After the module is initialized, simply call `.get(name: String)` on the module to return a namespaced logger:
+After the module is initialized, simply call `.get(name: String)` on the module to return a namespaced logger:  
 `const log = require('enrise-logger').get('MyLogger');`
 
 The `log` object contains functions for each [log-level](#levels):
+
 - `log.info('Some log message');`
 - `log.error(new Error('Some error'));`
 
@@ -58,8 +59,7 @@ The default configuration looks as follows. Everything can be overwritten on ini
 The top-level key `winston` in the config contains winston-specific configuration.
 
 #### `<namedloggerKey>: {level: String}`
-You can add other toplevel-keys
-to provide named-logger specific level-information. This functionality allows you to set the log-level through configuration
+You can add other toplevel-keys to provide named-logger specific level-information. This functionality allows you to set the log-level through configuration.
 
 ``` javascript
 {

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ function Logger(settings) {
 
   const winstonSettings = _.get(settings, 'winston', {});
 
-  this._settings = _.defaultsDeep(_.cloneDeep(winstonSettings), defaultSettings);
+  this._settings = _.defaultsDeep(_.cloneDeep(winstonSettings), _.get(defaultSettings, 'winston', {}));
   this._namedSettings = _.mapKeys(_.omit(settings, 'winston'), (v, k) => {return k.toUpperCase();});
   this._container = new winston.Container({
     exitOnError: false

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ function Logger(settings) {
 
   const winstonSettings = _.get(settings, 'winston', {});
 
-  this._settings = _.defaultsDeep(_.cloneDeep(winstonSettings), _.get(defaultSettings, 'winston', {}));
+  this._settings = _.defaultsDeep(_.cloneDeep(winstonSettings), defaultSettings.winston);
   this._namedSettings = _.mapKeys(_.omit(settings, 'winston'), (v, k) => {return k.toUpperCase();});
   this._container = new winston.Container({
     exitOnError: false

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "enrise-logger",
   "description": "Logger used within Enrise projects and module's",
-  "version": "0.2.1",
+  "version": "1.0.0",
   "author": "Team MatchMinds @ Enrise",
   "main": "index.js",
   "license": "MIT",

--- a/settings.js
+++ b/settings.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   transports: {
     Console: {

--- a/settings.js
+++ b/settings.js
@@ -1,22 +1,24 @@
 'use strict';
 
 module.exports = {
-  transports: {
-    Console: {
-      level: 'info',
-      colorize: true
+  winston: {
+    transports: {
+      Console: {
+        level: 'info',
+        colorize: true
+      }
+    },
+    longtrace: false,
+    levels: {
+      error: 0,
+      warn: 1,
+      help: 2,
+      data: 3,
+      info: 4,
+      trace: 5,
+      debug: 6,
+      prompt: 7,
+      verbose: 8
     }
-  },
-  longtrace: false,
-  levels: {
-    error: 0,
-    warn: 1,
-    help: 2,
-    data: 3,
-    info: 4,
-    trace: 5,
-    debug: 6,
-    prompt: 7,
-    verbose: 8
   }
 };


### PR DESCRIPTION
## What has been done
This is a feature which I missed based on my experience with log4net, the ability to change the loglevel scoped at the code-module level.
Within HdB we consequently `get` a named logger per module. This PR adds the ability to set the level for a named logger through the configuration. We are gonna use this for HDB-503, and add trace-level logging for sending the mail.

## Notes
This is a *breaking* change. Therefore the version is bumped to `1.0.0` From now on the configuration is divided in a (optional as we already have default-settings) `winston` part which used to be "the config", and optional extra parts of which the `key` will correspond with the named logger for which it needs to set the `Level`