### PR TITLE
Upgrade to v2: Node 20, winston 3, built-in LogstashUDP transport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
-coverage
+.nyc_output
+package-lock.json

--- a/.istanbul.yml
+++ b/.istanbul.yml
@@ -1,6 +1,0 @@
-check:
-  global:
-    statements: 100
-    lines: 100
-    branches: 100
-    functions: 100

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
- sudo: false
-
- language: node_js
- node_js: "4.2"
- 
- after_script: "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,76 @@
+# Changelog
+
+## 2.0.0
+
+### Breaking changes
+
+#### Node.js ≥ 20 required
+
+The minimum supported Node.js version has been raised from 4.0.0 to 20.
+
+#### winston upgraded from v2 to v3
+
+The underlying `winston` dependency has been upgraded from `^2.2.0` to `^3.19.0`. Consumers that build their own winston container (rather than using `.get()` from this package) need to update the following:
+
+**`logger.setLevels(levels)` removed**
+
+Pass `levels` directly to `container.get()` or `winston.createLogger()` instead:
+
+```js
+// Before
+const logger = container.get(label, { transports });
+logger.setLevels(levels);
+
+// After
+const logger = container.get(label, { transports, levels });
+```
+
+**`logger.rewriters` removed**
+
+The `rewriters` array no longer exists in winston v3. Replace it with a `winston.format` transform:
+
+```js
+// Before
+logger.rewriters.push((level, msg, meta) => { ... });
+
+// After (configure on the logger or transport)
+const { createLogger, format } = require('winston');
+const logger = createLogger({
+  format: format.combine(
+    format(info => {
+      // same transformation logic here
+      return info;
+    })()
+  ),
+  transports
+});
+```
+
+**Timestamps no longer included by default**
+
+In winston v2, log entries always included a `timestamp` field. In v3, add `winston.format.timestamp()` explicitly if your logstash consumer depends on it.
+
+#### `winston-logstash-udp` replaced with a built-in transport
+
+The third-party `winston-logstash-udp` package has been removed. An equivalent winston v3-compatible transport is now included in this package.
+
+**If you required `LogstashUDP` directly** (e.g. `require('winston-logstash-udp').LogstashUDP`), update the import:
+
+```js
+// Before
+const { LogstashUDP } = require('winston-logstash-udp');
+
+// After
+const LogstashUDP = require('enrise-logger/lib/logstash-udp-transport');
+```
+
+Alternatively, `winston.transports.LogstashUDP` is registered automatically when `enrise-logger` is required.
+
+The constructor options (`host`, `port`, `appName`, `localhost`, `pid`, `trailingLineFeed`, `trailingLineFeedChar`) are identical to the old package.
+
+### Other changes
+
+- Replaced `istanbul` with `nyc` for coverage reporting.
+- All devDependencies updated to current versions (`mocha`, `chai`, `sinon`, `sinon-chai`, `proxyquire`).
+- Production dependencies updated: `lodash` → 4.18.1, `longjohn` → 0.2.12.
+- Removed `.travis.yml` (CI no longer used).

--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
 # Node.js logger module
 
-[![build:?](https://img.shields.io/travis/Enrise/node-logger.svg?style=flat-square)](https://travis-ci.org/Enrise/node-logger)
-[![Coverage Status](https://img.shields.io/coveralls/Enrise/node-logger/master.svg?style=flat-square)](https://coveralls.io/github/Enrise/node-logger?branch=master)
-[![dependencies:?](https://img.shields.io/david/Enrise/node-logger.svg?style=flat-square)](https://david-dm.org/Enrise/node-logger)
-[![devDependencies:?](https://img.shields.io/david/dev/Enrise/node-logger.svg?style=flat-square)](https://david-dm.org/Enrise/node-logger)
-
 > A simple wrapper around [winston](https://github.com/winstonjs/winston).
 
 ## Deprecated
 This repository is deprecated and will be archived.
+
+### Requirements
+
+Node.js ≥ 20
 
 ### Installation
 NPM: `npm install enrise-logger --save`  
@@ -88,7 +87,7 @@ The keys define the transports that the logger should use, the value is the conf
 - `Console`: [winston.Console documentation](https://github.com/winstonjs/winston/blob/master/docs/transports.md#console-transport)
 - `File`: [winston.File documentation](https://github.com/winstonjs/winston/blob/master/docs/transports.md#file-transport)
 - `Http`: [winston.Http documentation](https://github.com/winstonjs/winston/blob/master/docs/transports.md#http-transport)
-- `LogstashUDP`: [winston.LogstashUDP documentation](https://www.npmjs.com/package/winston-logstash-udp)
+- `LogstashUDP`: built-in transport, options: `host`, `port`, `appName`, `localhost`, `pid`, `trailingLineFeed`, `trailingLineFeedChar`
 
 #### `winston.levels`
 The node-logger uses more detailed log-levels than winston does. The higher the priority the more important the message is considered to be, and the lower the corresponding integer priority. These levels can be modified to your liking.

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const defaultSettings = require('./settings.js');
 
 const _ = require('lodash');
 const winston = require('winston');
-require('winston-logstash-udp');
+winston.transports.LogstashUDP = require('./lib/logstash-udp-transport');
 
 function Logger(settings) {
   if (!(this instanceof Logger)) {
@@ -14,7 +14,7 @@ function Logger(settings) {
   const winstonSettings = _.get(settings, 'winston', {});
 
   this._settings = _.defaultsDeep(_.cloneDeep(winstonSettings), defaultSettings.winston);
-  this._namedSettings = _.mapKeys(_.omit(settings, 'winston'), (v, k) => {return k.toUpperCase();});
+  this._namedSettings = _.mapKeys(_.omit(settings, 'winston'), (v, k) => k.toUpperCase());
   this._container = new winston.Container({
     exitOnError: false
   });
@@ -38,7 +38,7 @@ Logger.prototype.get = function (label, level, transportConfig) {
   // Filter out falsey values
   const transportKeys = _.keys(_.pickBy(this._settings.transports, _.identity));
 
-  const transports = _.map(transportKeys, (transport) => {
+  const transports = _.map(transportKeys, transport => {
     const transportSettings = conf[transport];
 
     transportSettings.label = label;
@@ -49,8 +49,9 @@ Logger.prototype.get = function (label, level, transportConfig) {
 
   // Create a new logger with the console transport layer by default
   return this._container.get(label, {
-    transports: transports
-  }).setLevels(this._settings.levels);
+    transports,
+    levels: this._settings.levels
+  });
 };
 
 // Protect against usage without instantiation

--- a/lib/logstash-udp-transport.js
+++ b/lib/logstash-udp-transport.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const dgram = require('dgram');
+const os = require('os');
+const {Transport} = require('winston');
+
+class LogstashUDP extends Transport {
+  constructor(options = {}) {
+    super(options);
+    this.localhost = options.localhost || os.hostname();
+    this.host = options.host || '127.0.0.1';
+    this.port = options.port || 9999;
+    this.application = options.appName || process.title;
+    this.pid = options.pid || process.pid;
+    this.trailingLineFeed = options.trailingLineFeed === true;
+    this.trailingLineFeedChar = options.trailingLineFeedChar || os.EOL;
+    this.connect();
+  }
+
+  connect() {
+    this.client = dgram.createSocket('udp4');
+    this.client.on('error', () => {});
+  }
+
+  log(info, callback) {
+    const message = JSON.stringify(Object.assign({}, info, {
+      application: this.application,
+      serverName: this.localhost,
+      pid: this.pid
+    }));
+
+    this.sendLog(
+      this.trailingLineFeed ? message.replace(/\s+$/, '') + this.trailingLineFeedChar : message,
+      callback
+    );
+  }
+
+  sendLog(message, callback) {
+    const buf = Buffer.from(message);
+    this.client.send(buf, 0, buf.length, this.port, this.host, err => {
+      this.emit('logged', !err);
+      callback(err, !err);
+    });
+  }
+}
+
+module.exports = LogstashUDP;

--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
   "name": "enrise-logger",
   "description": "Logger used within Enrise projects and module's",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "author": "Team MatchMinds @ Enrise",
   "main": "index.js",
   "license": "MIT",
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=20"
   },
   "scripts": {
     "lint": "eslint index.js test",
     "unittest": "mocha test/*.spec.js",
-    "cover": "istanbul cover _mocha -- -R spec test/*.spec.js; istanbul check-coverage",
+    "cover": "nyc mocha 'test/*.spec.js'",
     "test": "npm run lint && npm run cover"
   },
   "repository": {
@@ -22,20 +22,26 @@
     "url": "https://github.com/Enrise/node-logger/issues"
   },
   "dependencies": {
-    "lodash": "^4.16.4",
-    "longjohn": "^0.2.11",
-    "winston": "^2.2.0",
-    "winston-logstash-udp": "^0.1.1"
+    "lodash": "^4.18.1",
+    "longjohn": "^0.2.12",
+    "winston": "^3.19.0"
+  },
+  "nyc": {
+    "check-coverage": true,
+    "statements": 100,
+    "lines": 100,
+    "branches": 100,
+    "functions": 100
   },
   "devDependencies": {
-    "chai": "^3.5.0",
-    "coveralls": "^2.11.14",
-    "eslint": "^3.8.1",
-    "eslint-config-mm": "^1.1.1",
-    "istanbul": "^0.4.5",
-    "mocha": "^3.1.2",
-    "proxyquire": "^1.7.10",
-    "sinon": "^1.17.6",
-    "sinon-chai": "^2.8.0"
+    "chai": "^6.2.2",
+    "coveralls": "^3.1.1",
+    "eslint": "^8.57.1",
+    "eslint-config-mm": "^2.0.0",
+    "mocha": "^11.7.5",
+    "nyc": "^18.0.0",
+    "proxyquire": "^2.1.3",
+    "sinon": "^22.0.0",
+    "sinon-chai": "^4.0.1"
   }
 }

--- a/test/logger.spec.js
+++ b/test/logger.spec.js
@@ -5,7 +5,7 @@ const sinon = require('sinon');
 const proxyquire = require('proxyquire').noCallThru();
 proxyquire.noPreserveCache();
 const expect = chai.expect;
-chai.use(require('sinon-chai'));
+chai.use(require('sinon-chai').default);
 
 const levels = {
   error: 0,
@@ -35,12 +35,13 @@ const winston = {
   loggers: {
     add: sinon.stub().returns(winstonCLI)
   },
-  Container: sinon.stub().returns(winstonContainer)
+  Container: sinon.stub().returns(winstonContainer),
+  transports: {}
 };
 
 // Keep reference to main (Proxied) Logger constructor.
 const ProxiedLogger = proxyquire('../index.js', {
-  winston: winston
+  winston
 });
 
 // When no need to verify stub-calls use the Logger
@@ -93,7 +94,7 @@ describe('Logger', () => {
           colorize: true
         }
       },
-      levels: levels
+      levels
     });
   });
 
@@ -108,7 +109,7 @@ describe('Logger', () => {
 
   it('correctly sets the log-levels', () => {
     new ProxiedLogger().get('TEST');
-    expect(winstonLogger.setLevels).to.have.been.calledWith(levels);
+    expect(winstonContainer.get).to.have.been.calledWith('TEST', sinon.match({levels}));
   });
 
   it('allows modifying the transports configuration', () => {

--- a/test/logstash-udp-transport.spec.js
+++ b/test/logstash-udp-transport.spec.js
@@ -1,0 +1,134 @@
+'use strict';
+
+const chai = require('chai');
+const sinon = require('sinon');
+const proxyquire = require('proxyquire').noCallThru();
+proxyquire.noPreserveCache();
+const expect = chai.expect;
+chai.use(require('sinon-chai').default);
+const os = require('os');
+
+function makeSocket() {
+  return {
+    on: sinon.stub(),
+    send: sinon.stub().callsFake((buf, offset, length, port, host, cb) => cb && cb(null))
+  };
+}
+
+function makeTransport(options, socketOverride) {
+  const socket = socketOverride || makeSocket();
+  const dgram = {createSocket: sinon.stub().returns(socket)};
+  const LogstashUDP = proxyquire('../lib/logstash-udp-transport', {dgram});
+  return {transport: new LogstashUDP(options), socket, dgram};
+}
+
+describe('LogstashUDP', () => {
+  it('registers itself on winston.transports', () => {
+    const winston = require('winston');
+    expect(winston.transports.LogstashUDP).to.be.a('function');
+  });
+
+  it('applies default options', () => {
+    const {transport} = makeTransport();
+    expect(transport.host).to.equal('127.0.0.1');
+    expect(transport.port).to.equal(9999);
+    expect(transport.localhost).to.equal(os.hostname());
+    expect(transport.application).to.equal(process.title);
+    expect(transport.pid).to.equal(process.pid);
+    expect(transport.trailingLineFeed).to.equal(false);
+  });
+
+  it('applies custom options', () => {
+    const {transport} = makeTransport({
+      host: '10.0.0.1',
+      port: 5000,
+      localhost: 'myhost',
+      appName: 'myapp',
+      pid: 42,
+      trailingLineFeed: true,
+      trailingLineFeedChar: '\n'
+    });
+    expect(transport.host).to.equal('10.0.0.1');
+    expect(transport.port).to.equal(5000);
+    expect(transport.localhost).to.equal('myhost');
+    expect(transport.application).to.equal('myapp');
+    expect(transport.pid).to.equal(42);
+    expect(transport.trailingLineFeed).to.equal(true);
+    expect(transport.trailingLineFeedChar).to.equal('\n');
+  });
+
+  it('creates a udp4 socket on connect', () => {
+    const {dgram} = makeTransport();
+    expect(dgram.createSocket).to.have.been.calledWith('udp4');
+  });
+
+  it('silently swallows socket errors', () => {
+    const {socket} = makeTransport();
+    const [, errorHandler] = socket.on.args.find(([event]) => event === 'error');
+    expect(() => errorHandler(new Error('socket error'))).to.not.throw();
+  });
+
+  it('sends a JSON payload via UDP on log()', done => {
+    const {transport, socket} = makeTransport({host: '10.0.0.1', port: 5000, appName: 'myapp', pid: 1});
+    const info = {level: 'info', message: 'hello'};
+
+    transport.log(info, () => {
+      expect(socket.send).to.have.been.called;
+      const sent = JSON.parse(socket.send.firstCall.args[0].toString());
+      expect(sent.level).to.equal('info');
+      expect(sent.message).to.equal('hello');
+      expect(sent.application).to.equal('myapp');
+      expect(sent.serverName).to.equal(transport.localhost);
+      expect(sent.pid).to.equal(1);
+      done();
+    });
+  });
+
+  it('sends to the configured host and port', done => {
+    const {transport, socket} = makeTransport({host: '10.0.0.1', port: 5000});
+    transport.log({level: 'info', message: 'x'}, () => {
+      expect(socket.send.firstCall.args[3]).to.equal(5000);
+      expect(socket.send.firstCall.args[4]).to.equal('10.0.0.1');
+      done();
+    });
+  });
+
+  it('appends trailing line feed when configured', done => {
+    const {transport, socket} = makeTransport({trailingLineFeed: true, trailingLineFeedChar: '\n'});
+    transport.log({level: 'info', message: 'x'}, () => {
+      const sent = socket.send.firstCall.args[0].toString();
+      expect(sent.endsWith('\n')).to.equal(true);
+      done();
+    });
+  });
+
+  it('does not append trailing line feed by default', done => {
+    const {transport, socket} = makeTransport();
+    transport.log({level: 'info', message: 'x'}, () => {
+      const sent = socket.send.firstCall.args[0].toString();
+      expect(sent.endsWith('\n')).to.equal(false);
+      done();
+    });
+  });
+
+  it('emits logged event after send', done => {
+    const {transport} = makeTransport();
+    transport.on('logged', result => {
+      expect(result).to.equal(true);
+      done();
+    });
+    transport.log({level: 'info', message: 'x'}, () => {});
+  });
+
+  it('passes send errors to callback', done => {
+    const socket = makeSocket();
+    const err = new Error('send failed');
+    socket.send.callsFake((buf, offset, length, port, host, cb) => cb(err));
+    const {transport} = makeTransport({}, socket);
+    transport.log({level: 'info', message: 'x'}, (cbErr, result) => {
+      expect(cbErr).to.equal(err);
+      expect(result).to.equal(false);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Node.js ≥ 20** — raises minimum engine requirement from 4.0.0
- **winston v2 → v3** — eliminates `util._extend` DEP0060 deprecation warning; adapts `container.get()` to pass `levels` directly (replaces removed `setLevels()`)
- **Built-in LogstashUDP transport** — replaces abandoned `winston-logstash-udp` package, which was completely broken with winston v3 (`common.clone` crash on first log + `Buffer()` DEP0005); the new transport in `lib/logstash-udp-transport.js` is a clean winston v3 class with identical constructor options and is still registered on `winston.transports.LogstashUDP`
- **istanbul → nyc** — replaces the ancient coverage tool with a modern one; thresholds moved into `package.json`
- **All dependencies updated** — lodash, longjohn, mocha, chai, sinon, sinon-chai, proxyquire, eslint, eslint-config-mm

## Consumer migration (see CHANGELOG.md)

Consumers that build their own winston container (e.g. the Crawler) need to update:

- `require('winston-logstash-udp').LogstashUDP` → `require('enrise-logger/lib/logstash-udp-transport')` (or use `winston.transports.LogstashUDP` after requiring enrise-logger)
- `logger.setLevels(levels)` → pass `levels` to `container.get(label, { transports, levels })`
- `logger.rewriters.push(...)` → replace with a `winston.format` transform