### PR TITLE
Auto-convert winston 2.x format options to winston 3.x formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 2.0.1
+
+### Changes
+
+#### Automatic conversion of winston 2.x transport format options
+
+Transport config keys that were removed in winston 3.x (`colorize`, `prettyPrint`, `padLevels`) are now automatically converted to their `winston.format` equivalents by the logger. Existing transport configuration requires no changes:
+
+```js
+new Logger({
+  winston: {
+    transports: {
+      Console: {
+        colorize: true,   // still works — converted to winston.format.colorize()
+        prettyPrint: true // still works — converted to winston.format.prettyPrint()
+      }
+    }
+  }
+});
+```
+
+Multiple options are combined into a single `winston.format.combine()` call.
+
+---
+
 ## 2.0.0
 
 ### Breaking changes

--- a/README.md
+++ b/README.md
@@ -89,5 +89,13 @@ The keys define the transports that the logger should use, the value is the conf
 - `Http`: [winston.Http documentation](https://github.com/winstonjs/winston/blob/master/docs/transports.md#http-transport)
 - `LogstashUDP`: built-in transport, options: `host`, `port`, `appName`, `localhost`, `pid`, `trailingLineFeed`, `trailingLineFeedChar`
 
+The following transport options from winston 2.x are automatically converted to their `winston.format` equivalents and can still be used as-is in transport config:
+
+| Option | Converted to |
+|---|---|
+| `colorize: true` | `winston.format.colorize()` |
+| `prettyPrint: true` | `winston.format.prettyPrint()` |
+| `padLevels: true` | `winston.format.padLevels()` |
+
 #### `winston.levels`
 The node-logger uses more detailed log-levels than winston does. The higher the priority the more important the message is considered to be, and the lower the corresponding integer priority. These levels can be modified to your liking.

--- a/index.js
+++ b/index.js
@@ -41,6 +41,25 @@ Logger.prototype.get = function (label, level, transportConfig) {
   const transports = _.map(transportKeys, transport => {
     const transportSettings = conf[transport];
 
+    // Convert removed winston 2.x format options to winston 3.x format instances.
+    // These options were removed in https://github.com/winstonjs/winston/blob/master/UPGRADE-3.0.md
+    const formats = [];
+    if (transportSettings.colorize) {
+      formats.push(winston.format.colorize());
+      delete transportSettings.colorize;
+    }
+    if (transportSettings.prettyPrint) {
+      formats.push(winston.format.prettyPrint());
+      delete transportSettings.prettyPrint;
+    }
+    if (transportSettings.padLevels) {
+      formats.push(winston.format.padLevels());
+      delete transportSettings.padLevels;
+    }
+    if (formats.length) {
+      transportSettings.format = winston.format.combine(...formats);
+    }
+
     transportSettings.label = label;
     transportSettings.level = levelToUse || transportSettings.level;
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "enrise-logger",
   "description": "Logger used within Enrise projects and module's",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": "Team MatchMinds @ Enrise",
   "main": "index.js",
   "license": "MIT",

--- a/test/logger.spec.js
+++ b/test/logger.spec.js
@@ -31,12 +31,24 @@ const winstonContainer = {
   get: sinon.stub().returns(winstonLogger)
 };
 
+// Unique sentinel objects so tests can identity-check which formats were applied
+const colorizeFormat = {name: 'colorize'};
+const prettyPrintFormat = {name: 'prettyPrint'};
+const padLevelsFormat = {name: 'padLevels'};
+const combinedFormat = {name: 'combined'};
+
 const winston = {
   loggers: {
     add: sinon.stub().returns(winstonCLI)
   },
   Container: sinon.stub().returns(winstonContainer),
-  transports: {}
+  transports: {},
+  format: {
+    colorize: sinon.stub().returns(colorizeFormat),
+    prettyPrint: sinon.stub().returns(prettyPrintFormat),
+    padLevels: sinon.stub().returns(padLevelsFormat),
+    combine: sinon.stub().returns(combinedFormat)
+  }
 };
 
 // Keep reference to main (Proxied) Logger constructor.
@@ -52,6 +64,10 @@ beforeEach(() => {
     Console: sinon.stub(),
     LogstashUDP: sinon.stub()
   };
+  winston.format.colorize.resetHistory();
+  winston.format.prettyPrint.resetHistory();
+  winston.format.padLevels.resetHistory();
+  winston.format.combine.resetHistory();
 });
 
 describe('Logger', () => {
@@ -102,7 +118,7 @@ describe('Logger', () => {
     new ProxiedLogger().get('TEST');
     expect(winston.transports.Console).to.have.been.calledWith({
       level: 'info',
-      colorize: true,
+      format: combinedFormat,
       label: 'TEST'
     });
   });
@@ -125,7 +141,7 @@ describe('Logger', () => {
     }).get('TEST');
     expect(winston.transports.Console).to.have.been.calledWith({
       level: 'info',
-      colorize: true,
+      format: combinedFormat,
       label: 'TEST'
     });
     expect(winston.transports.LogstashUDP).to.have.been.calledWith({
@@ -184,7 +200,7 @@ describe('Logger', () => {
 
     expect(winston.transports.Console).to.have.been.calledWith({
       level: 'info',
-      colorize: true,
+      format: combinedFormat,
       extra: 'settings',
       label: 'label'
     });
@@ -211,7 +227,7 @@ describe('Logger', () => {
     new ProxiedLogger(config).get('Number1');
     expect(winston.transports.Console).to.have.been.calledWith({
       level: 'trace',
-      colorize: true,
+      format: combinedFormat,
       label: 'Number1'
     });
     expect(winston.transports.LogstashUDP).to.have.been.calledWith({
@@ -222,12 +238,57 @@ describe('Logger', () => {
     new ProxiedLogger(config).get('Number2');
     expect(winston.transports.Console).to.have.been.calledWith({
       level: 'info',
-      colorize: true,
+      format: combinedFormat,
       label: 'Number2'
     });
     expect(winston.transports.LogstashUDP).to.have.been.calledWith({
       level: 'verbose',
       label: 'Number2'
+    });
+  });
+
+  describe('winston 2.x format option conversion', () => {
+    it('converts colorize: true to winston.format.colorize() and removes the key', () => {
+      new ProxiedLogger().get('TEST');
+      expect(winston.format.colorize).to.have.been.calledOnce;
+      expect(winston.format.combine).to.have.been.calledWith(colorizeFormat);
+      expect(winston.transports.Console).to.have.been.calledWith(sinon.match({format: combinedFormat}));
+      expect(winston.transports.Console).to.not.have.been.calledWith(sinon.match.has('colorize'));
+    });
+
+    it('converts prettyPrint: true to winston.format.prettyPrint() and removes the key', () => {
+      new ProxiedLogger({
+        winston: {transports: {Console: {colorize: null, prettyPrint: true}}}
+      }).get('TEST');
+      expect(winston.format.prettyPrint).to.have.been.calledOnce;
+      expect(winston.format.combine).to.have.been.calledWith(prettyPrintFormat);
+      expect(winston.transports.Console).to.have.been.calledWith(sinon.match({format: combinedFormat}));
+      expect(winston.transports.Console).to.not.have.been.calledWith(sinon.match.has('prettyPrint'));
+    });
+
+    it('converts padLevels: true to winston.format.padLevels() and removes the key', () => {
+      new ProxiedLogger({
+        winston: {transports: {Console: {colorize: null, padLevels: true}}}
+      }).get('TEST');
+      expect(winston.format.padLevels).to.have.been.calledOnce;
+      expect(winston.format.combine).to.have.been.calledWith(padLevelsFormat);
+      expect(winston.transports.Console).to.have.been.calledWith(sinon.match({format: combinedFormat}));
+      expect(winston.transports.Console).to.not.have.been.calledWith(sinon.match.has('padLevels'));
+    });
+
+    it('combines multiple format options into a single format.combine() call', () => {
+      new ProxiedLogger({
+        winston: {transports: {Console: {colorize: true, prettyPrint: true, padLevels: true}}}
+      }).get('TEST');
+      expect(winston.format.combine).to.have.been.calledWith(colorizeFormat, prettyPrintFormat, padLevelsFormat);
+    });
+
+    it('does not add a format when no format options are set', () => {
+      new ProxiedLogger({
+        winston: {transports: {Console: {colorize: null}}}
+      }).get('TEST');
+      expect(winston.format.combine).to.not.have.been.called;
+      expect(winston.transports.Console).to.not.have.been.calledWith(sinon.match.has('format'));
     });
   });
 });


### PR DESCRIPTION
## Summary

- Transport config keys that were silently dropped in the 2.0.0 upgrade (`colorize`, `prettyPrint`, `padLevels`) are now automatically converted to their `winston.format` equivalents inside `Logger.prototype.get()`
- Multiple options are combined into a single `winston.format.combine()` call and set as the `format` option on the transport
- Consumers do not need to change any configuration

## Test plan

- [x] `npm test` passes (28 tests, 100% coverage)